### PR TITLE
Improve documentation comments

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -12,7 +12,9 @@ import (
 	"time"
 )
 
-// Errors related to DNS Lookups.
+// Errors returned during DNS lookups.  They map directly to the
+// conditions described in RFC 7208 section 4.5 when locating and
+// selecting an SPF record.
 var (
 	ErrMultipleSPF = errors.New("filter found multiple spf records (permerror)")
 	ErrNoDNSrecord = errors.New("DNS record not found (NXDOMAIN)")
@@ -23,7 +25,9 @@ var (
 // DefaultDialTimeout is the fallback time out if the caller does not pass a deadline/cancellation.
 const DefaultDialTimeout = 5 * time.Second
 
-// TXTResolver fetches all TXT records for a domain.
+// TXTResolver abstracts DNS lookups for TXT records.  Implementations
+// should return all TXT strings for the supplied domain as required by
+// RFC 7208 section 3.3.
 type TXTResolver interface {
 	LookupTXT(ctx context.Context, domain string) ([]string, error)
 }
@@ -33,7 +37,9 @@ type DNSResolver struct {
 	resolver TXTResolver
 }
 
-// NewDNSResolver returns a DNSResolver whose lookups will honor ctx deadlines/cancellations.
+// NewDNSResolver returns a DNSResolver that performs TXT lookups using the
+// Go standard library.  Lookups respect context timeouts and cancellations so
+// callers can enforce the limits from RFC 7208 section 11.
 func NewDNSResolver() *DNSResolver {
 	r := &net.Resolver{
 		StrictErrors: true,
@@ -50,18 +56,23 @@ func NewDNSResolver() *DNSResolver {
 	return &DNSResolver{resolver: r}
 }
 
-// NewCustomDNSResolver allows callers to provide their own TXTResolver.
+// NewCustomDNSResolver builds a DNSResolver that delegates TXT lookups to the
+// provided implementation.  Use this for unit tests or when DNS queries need to
+// be customised.
 func NewCustomDNSResolver(r TXTResolver) *DNSResolver {
 	return &DNSResolver{resolver: r}
 }
 
-// LookupTXT returns all TXT records for domain using the underlying resolver
-// while honoring ctx deadlines and cancellations.
+// LookupTXT forwards the request to the underlying resolver.  The provided
+// context controls timeouts so callers remain compliant with the DNS
+// considerations in RFC 7208 section 11.
 func (d *DNSResolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
 	return d.resolver.LookupTXT(ctx, domain)
 }
 
-// getSPFRecord performs an RFC‑compliant SPF lookup.
+// getSPFRecord retrieves the TXT records for domain and selects the single
+// valid SPF record.  The behaviour mirrors the DNS processing rules from
+// RFC 7208 section 4.5.
 //   - NXDOMAIN → ("", ErrNoDNSrecord)
 //   - SERVFAIL/timeout → ErrTempfail
 //   - any other error → ErrPermfail
@@ -90,10 +101,11 @@ func getSPFRecord(ctx context.Context, domain string, r TXTResolver) (string, er
 	return filterSPF(txts)
 }
 
-// filterSPF picks exactly one "v=spf1" record (RFC 7208 section 4.5).
+// filterSPF selects exactly one "v=spf1" string from the provided TXT records.
+// The selection logic implements RFC 7208 section 4.5:
 //   - 0 records → ("", nil)
 //   - 1 record → (that record, nil)
-//   - >1 record → ("", ErrMultipleSPF)
+//   - more than 1 → ("", ErrMultipleSPF)
 func filterSPF(txts []string) (string, error) {
 	const spfV1 = "v=spf1"
 	var found []string
@@ -106,7 +118,7 @@ func filterSPF(txts []string) (string, error) {
 		}
 	}
 
-	// § 4.5: 0 → none; 1 → ok; >1 → permerror
+	// section 4.5: 0 → none; 1 → ok; >1 → permerror
 	switch len(found) {
 	case 0:
 		return "", nil // allowed


### PR DESCRIPTION
## Summary
- expand docs around DNS errors and SPF record filtering
- clarify DNS resolver behaviour
- document parser structures and helpers
- detail main SPF functions and helpers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686473529204832286dbe28316311f9d